### PR TITLE
Add in token management plugin

### DIFF
--- a/willing_zg/__init__.py
+++ b/willing_zg/__init__.py
@@ -1,8 +1,9 @@
 from . import resources
 from .custom_server import custom_server
 from .deployment import deployment
+from .tokens import token_util
 from importlib_metadata import version
 
-__all__ = ["resources", "custom_server", "deployment"]
+__all__ = ["resources", "custom_server", "deployment", "token_util"]
 
 __version__ = version("willing_zg")

--- a/willing_zg/resources/tokens.js
+++ b/willing_zg/resources/tokens.js
@@ -21,14 +21,11 @@ class TokenFetcher {
       this.accessToken = response.data.access;
       return true;
     } catch (error) {
-      console.log('error!');
       if (error.response) {
         if (error.response.status === 401) {
-          console.log('error and 401!');
           this.clearToken();
         }
       }
-      console.log('calling onError');
       this.onError(error);
     }
     return false;

--- a/willing_zg/tokens.js
+++ b/willing_zg/tokens.js
@@ -1,0 +1,62 @@
+const TOKEN_REFRESH_INTERVAL = 4 * 60 * 1000; // 4 min in ms
+
+// TODO change this up once portunus is deployed.
+const loginUrl = 'http://localhost:3000/login';
+
+class TokenFetcher {
+  constructor() {
+    this.fetchFunction = null;
+    this.onError = null;
+    this.accessToken = '';
+    this.timerId = null;
+  }
+
+  defaultOnError(_) {
+    window.location.replace(loginUrl);
+  }
+
+  async fetchToken() {
+    try {
+      const response = await this.fetchFunction();
+      this.accessToken = response.data.access;
+      return true;
+    } catch (error) {
+      console.log('error!');
+      if (error.response) {
+        if (error.response.status === 401) {
+          console.log('error and 401!');
+          this.clearToken();
+        }
+      }
+      console.log('calling onError');
+      this.onError(error);
+    }
+    return false;
+  }
+
+  clearToken() {
+    this.accessToken = '';
+    clearInterval(this.timerId);
+    this.timerId = null;
+  }
+
+  start(fetchFn, onError = this.defaultOnError) {
+    this.fetchFunction = fetchFn;
+    this.onError = onError;
+    if (!this.timerId) {
+      if (this.fetchToken()) {
+        this.timerId = setInterval(this.fetchToken, TOKEN_REFRESH_INTERVAL);
+      }
+    }
+  }
+}
+
+const tokenFetcher = new TokenFetcher();
+
+const isLoggedIn = () => {
+  // NOTE this will only be guaranteed to be up-to-date if the tokenFetcher is started on
+  // every page load.
+  return Bool(tokenFetcher.accessToken);
+};
+
+export { tokenFetcher, isLoggedIn };

--- a/willing_zg/tokens.py
+++ b/willing_zg/tokens.py
@@ -1,0 +1,17 @@
+from zygoat.components import FileComponent
+from zygoat.constants import FrontendUtils
+
+from . import resources
+
+
+TOKEN_FILE = "tokens.js"
+
+
+class TokenFile(FileComponent):
+    resource_pkg = resources
+    base_path = FrontendUtils
+    filename = TOKEN_FILE
+    overwrite = True
+
+
+token_util = TokenFile()


### PR DESCRIPTION
The idea is that, for apps like Members, on page load we'll check try and start managing access tokens automatically. The access tokens can then be used in all API requests. If we can't refresh a token, the user isn't logged in and will get redirected to portunus. If they are logged in, then they can continue on in the app.

Note that this currently doesn't handle pages that don't need authorization. @Ian-MacLeod and I have discussed it and Ian has an idea for a solution, but we'll get this out now.

edit: I tested this a bit but not really fully because of the problem above (I would navigate to the portunus login page and it would reload and reload and reload....) but the token refresher was working on error and i've tested the logic on success in earlier iterations.