### PR TITLE
Add in clearing token callbacks on success

### DIFF
--- a/willing_zg/resources/tokens.js
+++ b/willing_zg/resources/tokens.js
@@ -48,8 +48,7 @@ class TokenFetcher {
       const response = await this.fetchFunction();
       this.currentToken = response.data.access;
       this.onSuccess(this.currentToken);
-      this.tokenCallbacks.forEach(cb => cb(this.currentToken));
-      this.tokenCallbacks = [];
+      this.clearCallbacks();
       return true;
     } catch (error) {
       if (error.response) {
@@ -66,6 +65,12 @@ class TokenFetcher {
     this.currentToken = '';
     clearInterval(this.timerId);
     this.timerId = null;
+    this.clearCallbacks();
+  }
+
+  clearCallbacks() {
+    this.tokenCallbacks.forEach(cb => cb(this.currentToken));
+    this.tokenCallbacks = [];
   }
 
   start(fetchFn, onSuccess, onError) {


### PR DESCRIPTION
I made these in Portunus (https://github.com/MetLifeLegalPlans/portunus/pull/66) and forgot that I did and they need to go in here. If I remember rightly, we had unauthorized pages in Portunus never be able to get past the part where they were trying to get the token because they were trying to resolve a failure.

Sorry I forgot to separate this out, I only realized when I ran `zg update` again and it undid some changes made in that PR >.<

Tested with that PR.