### PR TITLE
TOKENS: rename portunus env var to use the NEXT_PUBLIC_ prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "willing-zg"
-version = "0.3.1"
+version = "0.3.2"
 description = ""
 readme = "README.md"
 authors = ["Bequest, Inc. <oss@willing.com>"]

--- a/willing_zg/resources/tokens.js
+++ b/willing_zg/resources/tokens.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const TOKEN_REFRESH_INTERVAL = 4 * 60 * 1000; // 4 min in ms
 
-export const PORTUNUS_URL = process.env.PORTUNUS_URL || 'https://dev.portunus.willing.com';
+export const PORTUNUS_URL = process.env.NEXT_PUBLIC_PORTUNUS_URL || 'https://dev.portunus.willing.com';
 
 const defaultFetch = () =>
   axios({ method: 'post', url: `${PORTUNUS_URL}/api/auth/token/refresh/`, withCredentials: true });


### PR DESCRIPTION
This is useful so that NextJS knows to expose this variable to the browser (see [here](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser)).