### PR TITLE
Avoid double encoding url parameters

### DIFF
--- a/willing_zg/resources/tokens.js
+++ b/willing_zg/resources/tokens.js
@@ -15,7 +15,7 @@ export const withReturn = url => {
     return url;
   }
   const params = new URLSearchParams();
-  params.append('next', encodeURIComponent(window.location.href));
+  params.append('next', window.location.href);
   return `${url}?${params.toString()}`;
 };
 


### PR DESCRIPTION
`URLSearchParams.toString` already handles the url encoding