### PR TITLE
TOKENS: update TokenFetcher to ensure access token is fresh before resolving

### DIFF
--- a/willing_zg/resources/mailer.py
+++ b/willing_zg/resources/mailer.py
@@ -70,5 +70,8 @@ class Mailer:
             [user.email],
             f"Account Notice: {subject}",
             "mlp_transactional_email",
-            {"user": user, "notice": text,},
+            {
+                "user": user,
+                "notice": text,
+            },
         )


### PR DESCRIPTION
The interval to update the access token is useful to avoid extra latency caused by making an extra network request whenever the token expires. We can't rely on setInterval to be completely accurate, though, and this can lead to using expired access tokens for api calls. This keeps the interval, but adds an explicit freshness check (and fetches a new one if it's stale) before resolving an access token value.