### PR TITLE
SESSIONS: add component to expire idle sessions based on DOM events

### DIFF
--- a/.github/workflows/test-output.yml
+++ b/.github/workflows/test-output.yml
@@ -13,7 +13,7 @@ jobs:
           architecture: 'x64'
       - uses: actions/setup-node@v1
         with:
-          node-version: '13.x'
+          node-version: '14.x'
       - name: Append path
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies

--- a/.github/workflows/test-output.yml
+++ b/.github/workflows/test-output.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: '13.x'
       - name: Append path
-        run: echo "::add-path::$HOME/.local/bin"
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           pip install poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "willing-zg"
-version = "1.3.3"
+version = "1.3.4"
 description = ""
 readme = "README.md"
 authors = ["Bequest, Inc. <oss@willing.com>"]

--- a/willing_zg/__init__.py
+++ b/willing_zg/__init__.py
@@ -7,6 +7,7 @@ from importlib_metadata import version
 from .django_willing_zg import django_willing_zg
 from .google_analytics import google_analytics
 from .chat import chat
+from .idle_session_handler import idle_session_handler
 
 __all__ = [
     "all_components",
@@ -16,7 +17,8 @@ __all__ = [
     "token_util",
     "django_willing_zg",
     "google_analytics",
-    "chat"
+    "chat",
+    "idle_session_handler"
 ]
 
 __version__ = version("willing_zg")

--- a/willing_zg/all_components.py
+++ b/willing_zg/all_components.py
@@ -6,6 +6,7 @@ from .tokens import token_util
 from .django_willing_zg import django_willing_zg
 from .google_analytics import google_analytics
 from .get_env import get_env_util
+from .idle_session_handler import idle_session_handler
 
 
 class AllComponents(Component):
@@ -20,5 +21,6 @@ all_components = AllComponents(
         get_env_util,
         django_willing_zg,
         google_analytics,
+        idle_session_handler,
     ]
 )

--- a/willing_zg/idle_session_handler.py
+++ b/willing_zg/idle_session_handler.py
@@ -1,0 +1,14 @@
+from zygoat.components import FileComponent
+from zygoat.constants import FrontendUtils
+
+from . import resources
+
+
+class IdleSessionHandler(FileComponent):
+    resource_pkg = resources
+    base_path = FrontendUtils
+    filename = "IdleSessionHandler.js"
+    overwrite = True
+
+
+idle_session_handler = IdleSessionHandler()

--- a/willing_zg/resources/IdleSessionHandler.js
+++ b/willing_zg/resources/IdleSessionHandler.js
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import root from 'window-or-global';
+
+import Modal from '@wui/basics/modal';
+
+const activeEvents = ['mousemove', 'click', 'scroll', 'keypress'];
+
+const IdleSessionHandler = ({ warningTime, expirationTime, expirationHandler }) => {
+  const [showWarning, setShowWarning] = useState(false);
+  const [expired, setExpired] = useState(false);
+  const [counter, setCounter] = useState(warningTime);
+  const [activeAt, setActiveAt] = useState(Date.now());
+  const tickCallback = useRef();
+  const resetCallback = useRef();
+
+  useEffect(() => {
+    tickCallback.current = () => {
+      if (expired) {
+        return;
+      }
+      const idleTime = Date.now() - activeAt;
+
+      const shouldShowWarning = idleTime > warningTime;
+      if (shouldShowWarning !== showWarning) {
+        setShowWarning(shouldShowWarning);
+      }
+
+      if (idleTime > expirationTime) {
+        expirationHandler();
+        setExpired(true);
+        setCounter(0);
+      } else {
+        setCounter(expirationTime - idleTime);
+      }
+    };
+  }, [expirationHandler, activeAt, expired, showWarning]);
+
+  useEffect(() => {
+    resetCallback.current = () => {
+      const now = Date.now();
+      if (now - activeAt > 1000) {
+        setActiveAt(Date.now());
+        setShowWarning(false);
+      }
+    };
+  }, [activeAt]);
+
+  useEffect(() => {
+    // The reset and tick callbacks can change while the component is mounted,
+    // so we must call them using their refs.
+    const resetIdleTimer = () => resetCallback.current();
+    activeEvents.forEach(e => root.addEventListener(e, resetIdleTimer));
+    const tickInterval = root.setInterval(() => tickCallback.current(), 1000);
+
+    return () => {
+      activeEvents.forEach(e => root.removeEventListener(e, resetIdleTimer));
+      root.clearInterval(tickInterval);
+    };
+  }, []);
+
+  return (
+    <Modal open={showWarning} title="Expiring session due to inactivity">
+      Your session will automatically expire in {Math.floor(counter / 1000)} seconds.
+    </Modal>
+  );
+};
+
+IdleSessionHandler.propTypes = {
+  warningTime: PropTypes.number,
+  expirationTime: PropTypes.number,
+  expirationHandler: PropTypes.func.isRequired,
+};
+
+IdleSessionHandler.defaultProps = {
+  warningTime: 25 * 60 * 1000,
+  expirationTime: 30 * 60 * 1000,
+};
+
+export default IdleSessionHandler;


### PR DESCRIPTION
Editing with more info:
Security auditors often ask for us to expire idle sessions after a certain period of time. The `IdleSessionComponent` tracks user activity using a number of DOM events and will call `expirationHandler` when 30 minutes (by default) has passed. It also shows a warning modal starting 5 minutes ahead of time.

A few things to note:
1. The warning modal uses a wui modal - it seems a safe assumption that our apps will be using WUI, but if we don't like that assumption it could use a render prop to display the warning instead.
2. The default timeout of 30 minutes is based on audit asks, but we could use a shorter time if we want to.
3. The events that I'm listening for are `mousemove`, `click`, `scroll`, and `keypress`, which seems to me to cover all the bases but let me know if there is something else that would be good to include.